### PR TITLE
Chore: update adserver-graphql dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,34 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.3.0] - 2023-09-20
-
-## [0.2.0] - 2023-09-20
-
-## [2.0.0] - 2023-05-30
-
-## [1.0.7] - 2023-05-30
-
-## [1.0.6] - 2023-05-30
-
-## [1.0.5] - 2023-04-27
-
 ### Changed
 
-- Implement error logging on console instead of OpenSearch while the app is in development.
+- Update adserver-graphql dependency
 
-## [1.0.4] - 2023-04-26
+## [0.0.3] - 2023-09-20
 
-### Changed
+### Added
 
-- Implemention of new `customPluginInfo` feature to pass information from the between resolvers.
-
-## [1.0.3] - 2023-04-25
-
-## [1.0.2] - 2023-04-21
-
-- Implement VBase for the `offersMap` used in the resolvers.
-
-## [1.0.1] - 2023-03-28
-
-## [1.0.0] - 2023-02-15
+- Implement the resolver

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     "node": "6.x"
   },
   "dependencies": {
-    "vtex.adserver-graphql": "0.x"
+    "vtex.adserver-graphql": "1.x"
   },
   "policies": [
     {

--- a/node/package.json
+++ b/node/package.json
@@ -28,7 +28,7 @@
     "@types/atob": "^2.1.2",
     "@types/jest": "^27.0.3",
     "@types/node": "^12.12.21",
-    "@vtex/api": "6.45.19",
+    "@vtex/api": "6.45.21",
     "@vtex/tsconfig": "^0.5.6",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -753,10 +753,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.45.19":
-  version "6.45.19"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.19.tgz#97b449850b517d6610e7123aa91caec2a29ae7b1"
-  integrity sha512-WUsAn1Oi+Z7Ih84DcRf4HQH85Mh+zO84L0ta7zuRyb13DoAEq2qMi0Mv6vZMd9BFWOCSD8AcTHVF/gZskwh9Yw==
+"@vtex/api@6.45.21":
+  version "6.45.21"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.21.tgz#2f5ea4a14dfbf426f6fbad140caf23c89060b313"
+  integrity sha512-Yo4og5bSM1n5WSQ3u8nsqEHicvxdyOZX3uA0KtQHbS4frSeA4hcGRuupsFHQ13eZZGMy4OR4fJO7ZQfkj8qLhQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What is the purpose of this pull request?

I published and deployed the v1.0.0 of the `adserver-graphql` schema. Since I selected a major version, some apps didn't updated it automatically. I'm updating the version here.

#### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
