### PR TITLE
Feature: satisfy the new adserver-graphql schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Satisfies the new adserver-graphql schema, adding the advertisement field into the sponsored product directly.
+
 ## [0.4.0] - 2023-09-21
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     "node": "6.x"
   },
   "dependencies": {
-    "vtex.adserver-graphql": "1.x"
+    "vtex.adserver-graphql": "0.x"
   },
   "policies": [
     {
@@ -24,9 +24,7 @@
   ],
   "billingOptions": {
     "free": true,
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/__tests__/resolvers/sponsoredProducts.test.ts
+++ b/node/__tests__/resolvers/sponsoredProducts.test.ts
@@ -26,7 +26,7 @@ describe('query sponsoredProducts', () => {
       ({ productId, campaignId, adId, actionCost }) => ({
         productId,
         identifier: {
-          field: 'id',
+          field: 'product',
           value: productId,
         },
         rule: { id: 'sponsoredProduct' },

--- a/node/__tests__/resolvers/sponsoredProducts.test.ts
+++ b/node/__tests__/resolvers/sponsoredProducts.test.ts
@@ -22,21 +22,23 @@ describe('query sponsoredProducts', () => {
   const query = resolvers.Query.sponsoredProducts
 
   describe('when the shopper is sorting products by relevance', () => {
-    const expectedResponse = {
-      sponsoredProducts: getSponsoredProductsResponse.sponsoredProducts.map(
-        ({ productId, campaignId, adId, actionCost }) => ({
-          productId,
-          rule: { id: 'sponsoredProduct' },
-          advertisement: {
-            campaignId,
-            adId,
-            actionCost,
-            adRequestId: getSponsoredProductsResponse.adRequestId,
-            adResponseId: getSponsoredProductsResponse.adResponseId,
-          },
-        })
-      ),
-    }
+    const expectedResponse = getSponsoredProductsResponse.sponsoredProducts.map(
+      ({ productId, campaignId, adId, actionCost }) => ({
+        productId,
+        identifier: {
+          field: 'id',
+          value: productId,
+        },
+        rule: { id: 'sponsoredProduct' },
+        advertisement: {
+          campaignId,
+          adId,
+          actionCost,
+          adRequestId: getSponsoredProductsResponse.adRequestId,
+          adResponseId: getSponsoredProductsResponse.adResponseId,
+        },
+      })
+    )
 
     it('queries the Ad Server and returns the ad response', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -51,7 +53,7 @@ describe('query sponsoredProducts', () => {
   })
 
   describe('when the shopper is sorting products by something other than relevance', () => {
-    const expectedResponse = { sponsoredProducts: [] }
+    const expectedResponse: SponsoredProduct[] = []
 
     const variables = {
       ...defaultVariables,

--- a/node/__tests__/resolvers/sponsoredProducts.test.ts
+++ b/node/__tests__/resolvers/sponsoredProducts.test.ts
@@ -23,9 +23,18 @@ describe('query sponsoredProducts', () => {
 
   describe('when the shopper is sorting products by relevance', () => {
     const expectedResponse = {
-      ...getSponsoredProductsResponse,
       sponsoredProducts: getSponsoredProductsResponse.sponsoredProducts.map(
-        ({ productId }) => ({ productId, rule: { id: 'sponsoredProduct' } })
+        ({ productId, campaignId, adId, actionCost }) => ({
+          productId,
+          rule: { id: 'sponsoredProduct' },
+          advertisement: {
+            campaignId,
+            adId,
+            actionCost,
+            adRequestId: getSponsoredProductsResponse.adRequestId,
+            adResponseId: getSponsoredProductsResponse.adResponseId,
+          },
+        })
       ),
     }
 

--- a/node/package.json
+++ b/node/package.json
@@ -28,7 +28,7 @@
     "@types/atob": "^2.1.2",
     "@types/jest": "^27.0.3",
     "@types/node": "^12.12.21",
-    "@vtex/api": "6.45.21",
+    "@vtex/api": "6.45.24",
     "@vtex/tsconfig": "^0.5.6",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",

--- a/node/resolvers/sponsoredProducts.ts
+++ b/node/resolvers/sponsoredProducts.ts
@@ -1,4 +1,7 @@
-import type { AdServerSearchParams } from '../typings/AdServer'
+import type {
+  AdServerResponse,
+  AdServerSearchParams,
+} from '../typings/AdServer'
 import compact from '../utils/compact'
 
 const RULE_ID = 'sponsoredProduct'
@@ -23,6 +26,30 @@ const getSearchParams = (args: SearchParams): AdServerSearchParams => {
   return compact(adServerSearchParams)
 }
 
+const mapSponsoredProduct = (
+  adResponse: AdServerResponse
+): SponsoredProduct[] => {
+  if (!adResponse?.sponsoredProducts) return []
+
+  return adResponse.sponsoredProducts?.map(
+    ({ productId, campaignId, adId, actionCost }) => {
+      const advertisement = {
+        campaignId,
+        adId,
+        actionCost,
+        adRequestId: adResponse?.adRequestId,
+        adResponseId: adResponse?.adResponseId,
+      }
+
+      return {
+        productId,
+        rule: { id: RULE_ID },
+        advertisement,
+      }
+    }
+  )
+}
+
 export async function sponsoredProducts(
   _: unknown,
   args: SearchParams,
@@ -35,11 +62,5 @@ export async function sponsoredProducts(
     searchParams: getSearchParams(args),
   })
 
-  return {
-    ...adResponse,
-    sponsoredProducts: adResponse.sponsoredProducts.map((product) => ({
-      ...product,
-      rule: { id: RULE_ID },
-    })),
-  }
+  return { sponsoredProducts: mapSponsoredProduct(adResponse) }
 }

--- a/node/resolvers/sponsoredProducts.ts
+++ b/node/resolvers/sponsoredProducts.ts
@@ -5,6 +5,7 @@ import type {
 import compact from '../utils/compact'
 
 const RULE_ID = 'sponsoredProduct'
+const PRODUCT_UNIQUE_IDENTIFIER_FIELD = 'id'
 const SPONSORED_PRODUCTS_COUNT = 2
 const RELEVANCE_DESC_SORT_STR = 'orderbyscoredesc'
 
@@ -43,6 +44,10 @@ const mapSponsoredProduct = (
 
       return {
         productId,
+        identifier: {
+          field: PRODUCT_UNIQUE_IDENTIFIER_FIELD,
+          value: productId,
+        },
         rule: { id: RULE_ID },
         advertisement,
       }
@@ -54,13 +59,13 @@ export async function sponsoredProducts(
   _: unknown,
   args: SearchParams,
   ctx: Context
-): Promise<AdResponse> {
-  if (!showSponsoredProducts(args)) return { sponsoredProducts: [] }
+): Promise<SponsoredProduct[]> {
+  if (!showSponsoredProducts(args)) return []
 
   const adResponse = await ctx.clients.adServer.getSponsoredProducts({
     count: SPONSORED_PRODUCTS_COUNT,
     searchParams: getSearchParams(args),
   })
 
-  return { sponsoredProducts: mapSponsoredProduct(adResponse) }
+  return mapSponsoredProduct(adResponse)
 }

--- a/node/resolvers/sponsoredProducts.ts
+++ b/node/resolvers/sponsoredProducts.ts
@@ -5,7 +5,7 @@ import type {
 import compact from '../utils/compact'
 
 const RULE_ID = 'sponsoredProduct'
-const PRODUCT_UNIQUE_IDENTIFIER_FIELD = 'id'
+const PRODUCT_UNIQUE_IDENTIFIER_FIELD = 'product'
 const SPONSORED_PRODUCTS_COUNT = 2
 const RELEVANCE_DESC_SORT_STR = 'orderbyscoredesc'
 

--- a/node/typings/AdServer.ts
+++ b/node/typings/AdServer.ts
@@ -7,7 +7,7 @@ export type AdServerRequest = {
 export type AdServerResponse = {
   adRequestId: string
   adResponseId: string
-  sponsoredProducts: SponsoredProduct[]
+  sponsoredProducts: AdServerSponsoredProduct[]
 }
 
 export type AdServerSearchParams = Pick<SearchParams, AdServerSearchParamsKeys>
@@ -20,7 +20,7 @@ type AdServerSearchParamsKeys =
   | 'searchState'
   | 'selectedFacets'
 
-type SponsoredProduct = {
+type AdServerSponsoredProduct = {
   campaignId: string
   adId: string
   productId: string

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -57,8 +57,24 @@ declare global {
   }
 
   type AdResponse = {
-    adRequestId?: string
-    adResponseId?: string
     sponsoredProducts: SponsoredProduct[]
+  }
+
+  type SponsoredProduct = {
+    productId: string
+    rule: Rule
+    advertisement?: Advertisement
+  }
+
+  type Rule = {
+    id: string
+  }
+
+  type Advertisement = {
+    campaignId: string
+    adId: string
+    actionCost: number
+    adRequestId: string
+    adResponseId: string
   }
 }

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -68,7 +68,7 @@ declare global {
     value: string
   }
 
-  type ProductUniqueIdentifierField = 'id' | 'sku'
+  type ProductUniqueIdentifierField = 'anuId' | 'skuId' | 'product'
 
   type Rule = {
     id: string

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -56,15 +56,19 @@ declare global {
     customPluginInfo?: string
   }
 
-  type AdResponse = {
-    sponsoredProducts: SponsoredProduct[]
-  }
-
   type SponsoredProduct = {
     productId: string
+    identifier: ProductUniqueIdentifier
     rule: Rule
     advertisement?: Advertisement
   }
+
+  type ProductUniqueIdentifier = {
+    field: ProductUniqueIdentifierField
+    value: string
+  }
+
+  type ProductUniqueIdentifierField = 'id' | 'sku'
 
   type Rule = {
     id: string

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -753,10 +753,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.45.21":
-  version "6.45.21"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.21.tgz#2f5ea4a14dfbf426f6fbad140caf23c89060b313"
-  integrity sha512-Yo4og5bSM1n5WSQ3u8nsqEHicvxdyOZX3uA0KtQHbS4frSeA4hcGRuupsFHQ13eZZGMy4OR4fJO7ZQfkj8qLhQ==
+"@vtex/api@6.45.24":
+  version "6.45.24"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.24.tgz#5643d80de9b5ac9491c03a47be0329872896a6eb"
+  integrity sha512-BaNdncM2Jfqdu/DikxrDVH7fdek5vH02nvH4RCyNcZ3KSSYZaKk4QGr2EjEHI/rhkOIbJOlOAW5ol4uDcGbQjQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Satisfies the changes in the schema made in https://github.com/vtex-apps/adserver-graphql/pull/2 by adding the `advertisement` field directly into the sponsored product object.

#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
