### PR TITLE
Pass `anonymousId` to Ad Server to allow A/B testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Send `anonymousId` as `userId` to ad server. This is used on A/B testing.
+
 ## [0.6.1] - 2023-12-04
 
 ## [0.6.0] - 2023-12-01

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,9 @@
   ],
   "billingOptions": {
     "free": true,
-    "availableCountries": ["*"]
+    "availableCountries": [
+      "*"
+    ]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/resolvers/sponsoredProducts.ts
+++ b/node/resolvers/sponsoredProducts.ts
@@ -66,6 +66,7 @@ export async function sponsoredProducts(
   const adResponse = await ctx.clients.adServer.getSponsoredProducts({
     count: SPONSORED_PRODUCTS_COUNT,
     searchParams: getSearchParams(args),
+    userId: args.anonymousId,
   })
 
   return mapSponsoredProduct(adResponse)

--- a/node/typings/AdServer.ts
+++ b/node/typings/AdServer.ts
@@ -2,6 +2,7 @@ export type AdServerRequest = {
   accountName?: string
   count: number
   searchParams: AdServerSearchParams
+  userId?: string
 }
 
 export type AdServerResponse = {

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -54,6 +54,7 @@ declare global {
     dynamicRules?: DynamicRule[]
     searchState?: string
     customPluginInfo?: string
+    anonymousId?: string
   }
 
   type SponsoredProduct = {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4415,7 +4415,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What is the purpose of this pull request?

We need to integrate A/B testing via Osiris. To do this, we need to pass `anonymousId` to Ad Server (as `userId`). We used `anonymousId` on GraphQL endpoints because there is a different ID when the user is logged in. Since we don't need this distinction on Ad Server, the `anonymousId` becomes `userId` there.

#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
