### PR TITLE
Fix: handles ad not found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Handles "Ad not found" error by returning an empty list.
+
 ## [0.7.0] - 2023-12-07
 
 ### Added

--- a/node/__tests__/resolvers/sponsoredProducts.test.ts
+++ b/node/__tests__/resolvers/sponsoredProducts.test.ts
@@ -1,3 +1,4 @@
+import AdServer from '../../clients/AdServer'
 import { resolvers } from '../../resolvers'
 import { getSponsoredProductsResponse } from '../__utils__/mocks/adServer'
 
@@ -22,34 +23,52 @@ describe('query sponsoredProducts', () => {
   const query = resolvers.Query.sponsoredProducts
 
   describe('when the shopper is sorting products by relevance', () => {
-    const expectedResponse = getSponsoredProductsResponse.sponsoredProducts.map(
-      ({ productId, campaignId, adId, actionCost, options }) => ({
-        productId,
-        identifier: {
-          field: 'product',
-          value: productId,
-        },
-        rule: { id: 'sponsoredProduct' },
-        advertisement: {
-          campaignId,
-          adId,
-          actionCost,
-          adRequestId: getSponsoredProductsResponse.adRequestId,
-          adResponseId: getSponsoredProductsResponse.adResponseId,
-          options,
-        },
-      })
-    )
+    describe('and the ad server returns sponsored products', () => {
+      const expectedResponse =
+        getSponsoredProductsResponse.sponsoredProducts.map(
+          ({ productId, campaignId, adId, actionCost, options }) => ({
+            productId,
+            identifier: {
+              field: 'product',
+              value: productId,
+            },
+            rule: { id: 'sponsoredProduct' },
+            advertisement: {
+              campaignId,
+              adId,
+              actionCost,
+              adRequestId: getSponsoredProductsResponse.adRequestId,
+              adResponseId: getSponsoredProductsResponse.adResponseId,
+              options,
+            },
+          })
+        )
 
-    it('queries the Ad Server and returns the ad response', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await query({}, defaultVariables, mockContext as any)
+      it('queries the Ad Server and returns the ad response', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await query({}, defaultVariables, mockContext as any)
 
-      expect(getSponsoredProductsSpy).toHaveBeenCalledWith({
-        count: 2,
-        searchParams: { query: 'shoes' },
+        expect(getSponsoredProductsSpy).toHaveBeenCalledWith({
+          count: 2,
+          searchParams: { query: 'shoes' },
+        })
+        expect(result).toMatchObject(expectedResponse)
       })
-      expect(result).toMatchObject(expectedResponse)
+    })
+
+    describe('and the ad server returns a "Ad Not Found" error', () => {
+      beforeEach(() => {
+        getSponsoredProductsSpy.mockRejectedValue({
+          response: { data: AdServer.ERROR_MESSAGES.AD_NOT_FOUND },
+        })
+      })
+
+      it('queries returns an empty list', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await query({}, defaultVariables, mockContext as any)
+
+        expect(result).toMatchObject([])
+      })
     })
   })
 

--- a/node/clients/AdServer.ts
+++ b/node/clients/AdServer.ts
@@ -6,6 +6,10 @@ import type { AdServerRequest, AdServerResponse } from '../typings/AdServer'
 class AdServer extends ExternalClient {
   public static BASE_URL = 'https://ad-server.vtex.systems'
 
+  public static ERROR_MESSAGES = {
+    AD_NOT_FOUND: 'Ad not found',
+  }
+
   constructor(ctx: IOContext, options?: InstanceOptions) {
     super(AdServer.BASE_URL, ctx, { ...options })
   }

--- a/node/resolvers/sponsoredProducts.ts
+++ b/node/resolvers/sponsoredProducts.ts
@@ -1,3 +1,4 @@
+import AdServer from '../clients/AdServer'
 import type {
   AdServerResponse,
   AdServerSearchParams,
@@ -63,11 +64,17 @@ export async function sponsoredProducts(
 ): Promise<SponsoredProduct[]> {
   if (!showSponsoredProducts(args)) return []
 
-  const adResponse = await ctx.clients.adServer.getSponsoredProducts({
-    count: SPONSORED_PRODUCTS_COUNT,
-    searchParams: getSearchParams(args),
-    userId: args.anonymousId,
-  })
+  try {
+    const adResponse = await ctx.clients.adServer.getSponsoredProducts({
+      count: SPONSORED_PRODUCTS_COUNT,
+      searchParams: getSearchParams(args),
+      userId: args.anonymousId,
+    })
 
-  return mapSponsoredProduct(adResponse)
+    return mapSponsoredProduct(adResponse)
+  } catch (error) {
+    if (error.response?.data === AdServer.ERROR_MESSAGES.AD_NOT_FOUND) return []
+
+    throw error
+  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

When the Ad Server returns "Ad not found", we return an empty list to the frontend.

<!--- Describe your changes in detail. -->

#### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
