### PR TITLE
Add regionalization support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/node_modules
+.idea

--- a/manifest.json
+++ b/manifest.json
@@ -20,13 +20,18 @@
         "host": "ad-server.vtex.systems",
         "path": "/api/v1/sponsored-products"
       }
+    },
+    {
+      "attrs": {
+        "host": "portal.vtexcommercestable.com.br",
+        "path": "/api/checkout/regions/*"
+      },
+      "name": "outbound-access"
     }
   ],
   "billingOptions": {
     "free": true,
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/__tests__/utils/region.test.ts
+++ b/node/__tests__/utils/region.test.ts
@@ -1,0 +1,109 @@
+import region from '../../utils/region'
+
+describe('region#toSelectedFacets', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let ctx: any
+
+  beforeEach(() => {
+    ctx = {
+      clients: {
+        checkout: {
+          regions: jest.fn(),
+        },
+      },
+    }
+  })
+
+  it('should return an array of selected facets', async () => {
+    ctx.clients.checkout.regions.mockResolvedValue([
+      { id: '1' },
+      { id: '2' },
+      { id: '3' },
+    ])
+
+    const result = await region.toSelectedFacets('1', ctx as unknown as Context)
+
+    expect(result).toMatchObject([
+      { key: 'private-seller', value: '1' },
+      { key: 'private-seller', value: '2' },
+      { key: 'private-seller', value: '3' },
+    ])
+  })
+
+  it('should return an empty array if regionId is undefined', async () => {
+    const result = await region.toSelectedFacets(
+      undefined,
+      ctx as unknown as Context
+    )
+
+    expect(result).toMatchObject([])
+  })
+
+  it('should return an empty array if checkout.regions returns undefined', async () => {
+    ctx.clients.checkout.regions.mockResolvedValue(undefined)
+
+    const result = await region.toSelectedFacets('1', ctx as unknown as Context)
+
+    expect(result).toMatchObject([])
+  })
+
+  it('should return an empty array if checkout.regions throws an error', async () => {
+    ctx.clients.checkout.regions.mockRejectedValue('Error')
+
+    const result = await region.toSelectedFacets('1', ctx as unknown as Context)
+
+    expect(result).toMatchObject([])
+  })
+})
+
+describe('region#fromSegment', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let ctx: any
+
+  beforeEach(() => {
+    ctx = {
+      clients: {
+        segment: {
+          getSegment: jest.fn(),
+        },
+      },
+      vtex: {
+        segmentToken: undefined,
+      },
+    }
+  })
+
+  it('should return the segment from client if segmentToken is undefined', async () => {
+    ctx.clients.segment.getSegment.mockResolvedValue({ regionId: '1' })
+
+    const result = await region.fromSegment(ctx as unknown as Context)
+
+    expect(result).toBe('1')
+  })
+
+  it('should return the segment from segmentToken if segmentToken is defined', async () => {
+    ctx.vtex.segmentToken = Buffer.from(
+      JSON.stringify({ regionId: '2' })
+    ).toString('base64')
+
+    const result = await region.fromSegment(ctx as unknown as Context)
+
+    expect(result).toBe('2')
+  })
+
+  it('should return undefined if segment.getSegment returns undefined', async () => {
+    ctx.clients.segment.getSegment.mockResolvedValue(undefined)
+
+    const result = await region.fromSegment(ctx as unknown as Context)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined if segment.getSegment throws an error', async () => {
+    ctx.clients.segment.getSegment.mockRejectedValue('Error')
+
+    const result = await region.fromSegment(ctx as unknown as Context)
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/node/clients/AdServer.ts
+++ b/node/clients/AdServer.ts
@@ -17,6 +17,11 @@ class AdServer extends ExternalClient {
   public getSponsoredProducts(
     body: AdServerRequest
   ): Promise<AdServerResponse> {
+    if (process.env.VTEX_APP_LINK) {
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(body, null, 2))
+    }
+
     return this.http.post('/api/v1/sponsored-products', {
       accountName: this.context.account,
       ...body,

--- a/node/clients/Checkout.ts
+++ b/node/clients/Checkout.ts
@@ -1,0 +1,28 @@
+import { JanusClient } from '@vtex/api'
+
+export type RegionSeller = {
+  id: string
+  name: string
+}
+
+export type Region = {
+  id: string
+  sellers: RegionSeller[]
+}
+
+class Checkout extends JanusClient {
+  public regions = (
+    regionId: string,
+    channel?: number | string
+  ): Promise<Region[]> => {
+    const url = `/api/checkout/pub/regions/${regionId}`
+
+    return this.http.get(url, {
+      params: {
+        sc: channel,
+      },
+    })
+  }
+}
+
+export default Checkout

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,9 +1,14 @@
 import { IOClients } from '@vtex/api'
 
 import AdServer from './AdServer'
+import Checkout from './Checkout'
 
 export class Clients extends IOClients {
   public get adServer() {
     return this.getOrSet('adServer', AdServer)
+  }
+
+  public get checkout() {
+    return this.getOrSet('checkout', Checkout)
   }
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,7 +1,6 @@
-// eslint-disable-next-line prettier/prettier
 import type { ParamsContext, RecorderState } from '@vtex/api'
 import { Service } from '@vtex/api'
-import schema from 'vtex.is-api-middleware-graphql/graphql'
+import schema from 'vtex.adserver-graphql/graphql'
 
 import { Clients } from './clients'
 import { resolvers } from './resolvers'

--- a/node/package.json
+++ b/node/package.json
@@ -22,13 +22,12 @@
   "dependencies": {
     "@vtex/clients": "^2.21.0",
     "graphql": "^14.5.8",
-    "vtex.is-api-middleware-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.0.1/public"
+    "vtex.adserver-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.0.1/public"
   },
   "devDependencies": {
-    "@types/atob": "^2.1.2",
     "@types/jest": "^27.0.3",
     "@types/node": "^12.12.21",
-    "@vtex/api": "6.46.0",
+    "@vtex/api": "6.46.1",
     "@vtex/tsconfig": "^0.5.6",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",

--- a/node/typings/AdServer.ts
+++ b/node/typings/AdServer.ts
@@ -13,13 +13,7 @@ export type AdServerResponse = {
 
 export type AdServerSearchParams = Pick<SearchParams, AdServerSearchParamsKeys>
 
-type AdServerSearchParamsKeys =
-  | 'query'
-  | 'regionId'
-  | 'operator'
-  | 'fuzzy'
-  | 'searchState'
-  | 'selectedFacets'
+type AdServerSearchParamsKeys = 'query' | 'selectedFacets'
 
 type AdServerSponsoredProduct = {
   campaignId: string

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/consistent-type-imports */
-import { ServiceContext } from '@vtex/api'
-
-import { Clients } from '../clients/index'
+import type { ServiceContext } from '@vtex/api'
+import type { Clients } from '../clients'
 
 declare global {
   type Context = ServiceContext<Clients>

--- a/node/utils/region.ts
+++ b/node/utils/region.ts
@@ -1,0 +1,56 @@
+async function toSelectedFacets(
+  regionId: string | undefined,
+  ctx: Context
+): Promise<SelectedFacet[]> {
+  const {
+    clients: { checkout },
+    vtex: { logger },
+  } = ctx
+
+  if (!regionId) {
+    return []
+  }
+
+  try {
+    // eslint-disable-next-line no-console
+    console.log(regionId)
+    const regions = (await checkout.regions(regionId)) ?? []
+
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(regions))
+    const region = regions.find((r) => r.id === regionId)
+    const sellers = region?.sellers ?? []
+
+    return sellers.map((seller) => ({
+      key: 'private-seller',
+      value: seller.id,
+    }))
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(e))
+    logger.error(e)
+
+    return []
+  }
+}
+
+async function fromSegment(ctx: Context): Promise<string | undefined> {
+  const {
+    clients: { segment },
+    vtex: { segmentToken, logger },
+  } = ctx
+
+  try {
+    const segmentData = segmentToken
+      ? JSON.parse(Buffer.from(segmentToken, 'base64').toString())
+      : await segment.getSegment()
+
+    return segmentData?.regionId
+  } catch (e) {
+    logger.error(e)
+
+    return undefined
+  }
+}
+
+export default { toSelectedFacets, fromSegment }

--- a/node/utils/region.ts
+++ b/node/utils/region.ts
@@ -12,12 +12,7 @@ async function toSelectedFacets(
   }
 
   try {
-    // eslint-disable-next-line no-console
-    console.log(regionId)
     const regions = (await checkout.regions(regionId)) ?? []
-
-    // eslint-disable-next-line no-console
-    console.log(JSON.stringify(regions))
     const region = regions.find((r) => r.id === regionId)
     const sellers = region?.sellers ?? []
 
@@ -26,8 +21,6 @@ async function toSelectedFacets(
       value: seller.id,
     }))
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.log(JSON.stringify(e))
     logger.error(e)
 
     return []

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -534,11 +534,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/atob@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@types/atob/-/atob-2.1.2.tgz#157eb0cc46264a8c55f2273a836c7a1a644fb820"
-  integrity sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==
-
 "@types/babel__core@^7.1.7":
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.2.tgz#215db4f4a35d710256579784a548907237728756"
@@ -753,10 +748,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.46.0":
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.0.tgz#208d14b96cbc8fd5eb6bd18fbd0c8424886e6154"
-  integrity sha512-XAvJlD1FG1GynhPXiMcayunahFCL2r3ilO5MHAWKxYvB/ljyxi4+U+rVpweeaQGpxHfhKHdfPe7qNEEh2oa2lw==
+"@vtex/api@6.46.1":
+  version "6.46.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.1.tgz#55a8755ae48f5400e7f1ed1921cd547950bb7a2a"
+  integrity sha512-geoxVvyWoQpOQ70Zmx3M8SBkRoGOS/bp9Gy26M+iCue63jofVSwmFz1zf66EaHA1PKOJNRgQPFwY+oeDE1U2lQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4896,7 +4891,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.is-api-middleware-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.0.1/public":
+"vtex.adserver-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.0.1/public":
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.0.1/public#202d7f442dadfe4e4427747808fcda5134bc5a08"
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->
We need to grab the `regionId` supplied and transform it into a list of
private-sellers, this way, the `search-api` will be able to correctly
regionalize the requests.

#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
