### PR TITLE
Fix: use correct ad not found message from ad server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+- Correct "Ad not found" error message.
+
 ## [0.7.2] - 2024-02-07
 
 ## [0.7.1] - 2023-12-11

--- a/node/clients/AdServer.ts
+++ b/node/clients/AdServer.ts
@@ -7,7 +7,7 @@ class AdServer extends ExternalClient {
   public static BASE_URL = 'https://ad-server.vtex.systems'
 
   public static ERROR_MESSAGES = {
-    AD_NOT_FOUND: 'Ad not found',
+    AD_NOT_FOUND: 'Ad not found\n',
   }
 
   constructor(ctx: IOContext, options?: InstanceOptions) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Use the new "Ad not found" message from Ad Server to know when to return an empty array or raise an exception.

<!--- Describe your changes in detail. -->

#### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
