### PR TITLE
Fix: correct not found message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct "not found" message from the Ad Server.
+
 ## [2.1.0] - 2024-07-09
 
 ### Added
 
-- Pass `placement` and `count` from the frontend to the Ad Server;
+- Pass `placement` and `count` from the frontend to the Ad Server.
 
 ## [2.0.0] - 2024-04-22
 

--- a/node/clients/AdServer.ts
+++ b/node/clients/AdServer.ts
@@ -7,7 +7,7 @@ class AdServer extends ExternalClient {
   public static BASE_URL = 'https://ad-server.vtex.systems'
 
   public static ERROR_MESSAGES = {
-    AD_NOT_FOUND: 'Ad not found\n',
+    AD_NOT_FOUND: 'Ad not found',
   }
 
   constructor(ctx: IOContext, options?: InstanceOptions) {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4410,7 +4410,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What is the purpose of this pull request?

The AdServer has changed its "Not found" message, so we were throwing an error if the query didn't return a sponsored product.

This didn't affect any store, since there's a safeguard on Intelligent Search API that always returns `[]` if any error occurs in the Ad Server resolver call.

#### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
