### PR TITLE
Feature: disable ads on collections with config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add the `enableAdsOnCollections` setting, determining whether or not to fetch sponsored products on collections.
+
 ## [2.1.1] - 2024-07-09
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "vendor": "vtex",
   "name": "adserver-resolver",
   "version": "2.1.1",
-  "title": "adserver resolver",
-  "description": "Adserver resolver",
+  "title": "Ad Server Resolver",
+  "description": "Configurations for sponsored products on your store",
   "builders": {
     "node": "6.x"
   },
@@ -29,5 +29,17 @@
       "name": "outbound-access"
     }
   ],
+  "settingsSchema": {
+    "title": "vtex.adserver-resolver",
+    "type": "object",
+    "properties": {
+      "enableAdsOnCollections": {
+        "title": "Enable sponsored products on collections",
+        "description": "If checked, sponsored products will be displayed on product collections.",
+        "type": "boolean",
+        "default": true
+      }
+    }
+  },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/resolvers/sponsoredProducts.ts
+++ b/node/resolvers/sponsoredProducts.ts
@@ -5,16 +5,11 @@ import type {
 } from '../typings/AdServer'
 import compact from '../utils/compact'
 import region from '../utils/region'
+import { shouldFetchSponsoredProducts } from '../utils/shouldFetchSponsoredProducts'
 
 const RULE_ID = 'sponsoredProduct'
 const PRODUCT_UNIQUE_IDENTIFIER_FIELD = 'product'
 const DEFAULT_SPONSORED_COUNT = 3
-const RELEVANCE_DESC_SORT_STR = 'orderbyscoredesc'
-
-// Only show sponsored products in the default sort (Relevance).
-const showSponsoredProducts = (args: SearchParams) => {
-  return !args.sort || args.sort?.toLowerCase() === RELEVANCE_DESC_SORT_STR
-}
 
 const getSearchParams = (
   args: SearchParams,
@@ -62,7 +57,9 @@ export async function sponsoredProducts(
   args: SponsoredProductsParams,
   ctx: Context
 ): Promise<SponsoredProduct[]> {
-  if (!showSponsoredProducts(args)) return []
+  const shouldFetch = await shouldFetchSponsoredProducts(args, ctx)
+
+  if (!shouldFetch) return []
 
   const regionId = args.regionId ?? (await region.fromSegment(ctx))
   const privateSellers = await region.toSelectedFacets(regionId, ctx)

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -46,6 +46,7 @@ declare global {
     count?: string
     sort?: string
     operator?: string
+    map?: string
     fuzzy?: string
     locale?: string
     allowRedirect?: boolean

--- a/node/utils/shouldFetchSponsoredProducts.ts
+++ b/node/utils/shouldFetchSponsoredProducts.ts
@@ -1,0 +1,39 @@
+const RELEVANCE_DESC_SORT_STR = 'orderbyscoredesc'
+const PRODUCT_CLUSTER_MAP = 'productClusterIds'
+
+const isSortedByRelevance = (args: SearchParams) => {
+  return !args.sort || args.sort?.toLowerCase() === RELEVANCE_DESC_SORT_STR
+}
+
+const queryHasProductClusters = (args: SearchParams) => {
+  const mapHasProductClusters = args.map === PRODUCT_CLUSTER_MAP
+  const facetsHaveProductClusters = args.selectedFacets?.some(
+    (facet) => facet.key === PRODUCT_CLUSTER_MAP
+  )
+
+  return mapHasProductClusters || facetsHaveProductClusters
+}
+
+const shouldFetchOnProductClusers = async (ctx: Context) => {
+  const settings = await ctx.clients.apps.getAppSettings(
+    'vtex.adserver-resolver'
+  )
+
+  return settings?.enableAdsOnCollections ?? true
+}
+
+/**
+ * Determine whether or not to fetch sponsored products based on a few parameters:
+ * 1. If the search is not sorted by relevance, don't fetch.
+ * 2. If the search is not for a product cluster (collections), fetch.
+ * 3. If the search is for a product cluster, fetch if the feature is enabled.
+ */
+export const shouldFetchSponsoredProducts = async (
+  args: SearchParams,
+  ctx: Context
+) => {
+  if (!isSortedByRelevance(args)) return false
+  if (!queryHasProductClusters(args)) return true
+
+  return shouldFetchOnProductClusers(ctx)
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Some accounts don't desire sponsored products on their product collections. So, we're adding a setting (via app store config) that determines if we should show the ad if a collection is requests.

#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
