### PR TITLE
Feat/ add seller_id in sponsoredProducts

### DIFF
--- a/node/resolvers/sponsoredProducts.ts
+++ b/node/resolvers/sponsoredProducts.ts
@@ -47,7 +47,7 @@ const mapSponsoredProduct = (
         },
         rule: { id: RULE_ID },
         advertisement,
-        sellerId: "",
+        sellerId: undefined,
       }
     }
   )

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -66,7 +66,7 @@ declare global {
     identifier: ProductUniqueIdentifier
     rule: Rule
     advertisement?: Advertisement
-    sellerId: string
+    sellerId?: string
   }
 
   type ProductUniqueIdentifier = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

In order to integrate the Adserver with Newtail we have created a new resolver [newtail-resolver ](https://github.com/vtex-apps/ads-newtail-resolver) and we need to identify the products by sku_id and seller_id, because of that we have a PR that is responsible for change the [adserver graphQL PR](https://github.com/vtex-apps/adserver-graphql/pull/7)  and we need to ensure that adserver-resolver also returns this `field`.

Since we do not have this field from adResponse and we do need it, we are sending an empty string


#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
