### PR TITLE
feat(sponsoredProducts): add macId and userId to SponsoredProductsParams

### DIFF
--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -38,6 +38,8 @@ declare global {
   type SponsoredProductsParams = SearchParams & {
     placement?: string
     sponsoredCount?: number
+    macId?: string
+    userId?: string
   }
 
   type SearchParams = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->
We are adding optional parameters provided by `sponsoredProducts` query schema (macId and userId) ([PR schema](https://github.com/vtex-apps/adserver-graphql/pull/8))

#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
