### PR TITLE
feat: Merge Newtail resolver into this app

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,13 @@
         "path": "/api/checkout/regions/*"
       },
       "name": "outbound-access"
+    },
+    {
+      "attrs": {
+        "host": "newtail-media.newtail.com.br",
+        "path": "*"
+      },
+      "name": "outbound-access"
     }
   ],
   "settingsSchema": {

--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,7 @@
     }
   ],
   "settingsSchema": {
-    "title": "vtex.adserver-resolver",
+    "title": "AdServer Resolver",
     "type": "object",
     "properties": {
       "enableAdsOnCollections": {
@@ -45,6 +45,18 @@
         "description": "If checked, sponsored products will be displayed on product collections.",
         "type": "boolean",
         "default": true
+      },
+      "enableNewtail": {
+        "title": "Enable Newtail",
+        "description": "If checked, Newtail will be used to display sponsored products.",
+        "type": "boolean",
+        "default": false
+      },
+      "newtailPublisherId": {
+        "title": "Newtail Publisher ID",
+        "description": "The publisher ID provided by Newtail.",
+        "type": "string",
+        "default": ""
       }
     }
   },

--- a/node/clients/Newtail.ts
+++ b/node/clients/Newtail.ts
@@ -20,11 +20,6 @@ class Newtail extends ExternalClient {
   ): Promise<NewtailResponse> {
     const endpoint = `/v1/rma/${newtailPublisherId}`
 
-    // TODO: remove it after kobe fix
-    if (this.context.account === 'americanas') {
-      body.user_id = body.session_id
-    }
-
     return this.http
       .post<NewtailResponse>(endpoint, {
         ...body,

--- a/node/clients/Newtail.ts
+++ b/node/clients/Newtail.ts
@@ -1,0 +1,50 @@
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { ExternalClient } from '@vtex/api'
+
+import type { NewtailRequest, NewtailResponse } from '../typings/Newtail'
+
+const NEWTAIL_PUBLISHERS_ID: { [key: string]: string } = {
+  americanasqa: '1da8ef01-58c8-48bc-9086-038fcb3aeeb3',
+  biggy: '1da8ef01-58c8-48bc-9086-038fcb3aeeb3',
+  americanas: '4d600792-e73a-4e3f-b7b1-0447b8c4bb94',
+  fastshopbr: '974b02b9-bfda-4a7c-ac10-2bd5b1d29a37',
+  paguemenos: '47e240a0-61f7-46fd-8056-81288de6d724',
+}
+
+class Newtail extends ExternalClient {
+  public static BASE_URL = 'https://newtail-media.newtail.com.br'
+
+  public static ERROR_MESSAGES = {
+    AD_NOT_FOUND: 'Ad not found',
+  }
+
+  constructor(ctx: IOContext, options?: InstanceOptions) {
+    super(Newtail.BASE_URL, ctx, { ...options })
+  }
+
+  public async getSponsoredProducts(
+    body: NewtailRequest
+  ): Promise<NewtailResponse> {
+    const newtailPublisherId = NEWTAIL_PUBLISHERS_ID[this.context.account]
+    const endpoint = `/v1/rma/${newtailPublisherId}`
+
+    // TODO: remove it after kobe fix
+    if (this.context.account === 'americanas') {
+      body.user_id = body.session_id
+    }
+
+    return this.http
+      .post<NewtailResponse>(endpoint, {
+        ...body,
+      })
+      .then((response) => {
+        if (response.validations && response.validations.length > 0) {
+          throw new Error('Newtail validation error')
+        }
+
+        return response
+      })
+  }
+}
+
+export default Newtail

--- a/node/clients/Newtail.ts
+++ b/node/clients/Newtail.ts
@@ -3,14 +3,6 @@ import { ExternalClient } from '@vtex/api'
 
 import type { NewtailRequest, NewtailResponse } from '../typings/Newtail'
 
-const NEWTAIL_PUBLISHERS_ID: { [key: string]: string } = {
-  americanasqa: '1da8ef01-58c8-48bc-9086-038fcb3aeeb3',
-  biggy: '1da8ef01-58c8-48bc-9086-038fcb3aeeb3',
-  americanas: '4d600792-e73a-4e3f-b7b1-0447b8c4bb94',
-  fastshopbr: '974b02b9-bfda-4a7c-ac10-2bd5b1d29a37',
-  paguemenos: '47e240a0-61f7-46fd-8056-81288de6d724',
-}
-
 class Newtail extends ExternalClient {
   public static BASE_URL = 'https://newtail-media.newtail.com.br'
 
@@ -23,9 +15,9 @@ class Newtail extends ExternalClient {
   }
 
   public async getSponsoredProducts(
-    body: NewtailRequest
+    body: NewtailRequest,
+    newtailPublisherId: string
   ): Promise<NewtailResponse> {
-    const newtailPublisherId = NEWTAIL_PUBLISHERS_ID[this.context.account]
     const endpoint = `/v1/rma/${newtailPublisherId}`
 
     // TODO: remove it after kobe fix

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -2,10 +2,15 @@ import { IOClients } from '@vtex/api'
 
 import AdServer from './AdServer'
 import Checkout from './Checkout'
+import Newtail from './Newtail'
 
 export class Clients extends IOClients {
   public get adServer() {
     return this.getOrSet('adServer', AdServer)
+  }
+
+  public get newtail() {
+    return this.getOrSet('newtail', Newtail)
   }
 
   public get checkout() {

--- a/node/resolvers/newtailSponsoredProducts.ts
+++ b/node/resolvers/newtailSponsoredProducts.ts
@@ -1,0 +1,122 @@
+import Newtail from '../clients/Newtail'
+import type {
+  NewtailResponse,
+  NewtailPlacement,
+  PlacementResponse,
+  NewtailRequest,
+} from '../typings/Newtail'
+import { shouldFetchSponsoredProducts } from '../utils/shouldFetchSponsoredProducts'
+
+const RULE_ID = 'sponsoredProduct'
+const PRODUCT_SKU_IDENTIFIER_FIELD = 'skuId'
+const DEFAULT_SPONSORED_COUNT = 3
+const DEFAULT_PLACEMENT_NAME = 'ads_newtail'
+const DEFAULT_CAMPAIGN_ID = ''
+
+const getPlacementList = (
+  newtailResponse: NewtailResponse,
+  placement: string
+): PlacementResponse[] => {
+  return (newtailResponse[placement] as PlacementResponse[]) ?? []
+}
+
+const encodeBase64 = (str: string): string => {
+  return Buffer.from(str).toString('base64')
+}
+
+const mapSponsoredProduct = (
+  newtailResponse: NewtailResponse,
+  placement = DEFAULT_PLACEMENT_NAME
+): SponsoredProduct[] => {
+  const placementList: PlacementResponse[] = getPlacementList(
+    newtailResponse,
+    placement
+  )
+
+  if (placementList.length === 0) return []
+
+  return placementList?.map(
+    ({ product_sku, impression_url, seller_id, product_metadata }) => {
+      const advertisement = {
+        campaignId: DEFAULT_CAMPAIGN_ID,
+        adId: encodeBase64(impression_url),
+        actionCost: 0.0,
+
+        adRequestId: newtailResponse?.request_id,
+        adResponseId: newtailResponse?.query_id,
+      }
+
+      return {
+        productId: product_metadata.productId,
+        identifier: {
+          field: PRODUCT_SKU_IDENTIFIER_FIELD,
+          value: product_sku,
+        },
+        rule: { id: RULE_ID },
+        advertisement,
+        sellerId: seller_id,
+      }
+    }
+  )
+}
+
+const definePlacements = (
+  quantity: number,
+  placement = DEFAULT_PLACEMENT_NAME
+): { [key: string]: NewtailPlacement } => {
+  const placements: { [key: string]: NewtailPlacement } = {
+    [placement]: {
+      quantity,
+      types: ['product'],
+    },
+  }
+
+  return placements
+}
+
+const validateParams = (args: SponsoredProductsParams): void => {
+  if (!args.macId) {
+    throw new Error("macId is required but was not provided.");
+  }
+}
+export async function newtailSponsoredProducts(
+  _: unknown,
+  args: SponsoredProductsParams,
+  ctx: Context
+): Promise<SponsoredProduct[]> {
+  validateParams(args);
+
+  const shouldFetch = await shouldFetchSponsoredProducts(args, ctx)
+  if (!shouldFetch) return []
+
+  try {
+    const adsAmount = args.sponsoredCount ?? DEFAULT_SPONSORED_COUNT
+
+    const categoryName =
+      args?.selectedFacets?.length && args.selectedFacets.some((facet) => facet.key.startsWith("category"))
+        ? args.selectedFacets
+            .filter((facet) => facet.key.startsWith("category"))
+            .map((facet) => facet.value)
+            .join(" > ")
+        : undefined;
+
+    const context = args?.query?.length ? 'search' : (categoryName ? 'category' : 'home')
+
+    const body: NewtailRequest = {
+      term: args.query,
+      context,
+      category_name: categoryName,
+      placements: definePlacements(adsAmount, args.placement),
+      user_id: args.userId,
+      session_id: args.macId,
+    }
+
+    const newtailResponse = await ctx.clients.newtail.getSponsoredProducts(body)
+
+    return mapSponsoredProduct(newtailResponse, args.placement)
+  } catch (error) {
+    if (error.response?.data === Newtail.ERROR_MESSAGES.AD_NOT_FOUND) return []
+
+    throw error
+  }
+}

--- a/node/resolvers/sponsoredProducts/index.ts
+++ b/node/resolvers/sponsoredProducts/index.ts
@@ -1,0 +1,17 @@
+import {shouldUseNewtail} from "../../utils/shouldUseNewtail";
+import {newtailSponsoredProducts} from "./newtail";
+import {vtexSponsoredProducts} from "./vtex";
+
+
+export async function sponsoredProducts(
+  arg: unknown,
+  params: SponsoredProductsParams,
+  ctx: Context
+): Promise<SponsoredProduct[]> {
+  const should = await shouldUseNewtail(ctx)
+  if (should) {
+    return newtailSponsoredProducts(arg, params, ctx)
+  }
+
+  return vtexSponsoredProducts(arg, params, ctx)
+}

--- a/node/resolvers/sponsoredProducts/newtail.ts
+++ b/node/resolvers/sponsoredProducts/newtail.ts
@@ -1,11 +1,12 @@
-import Newtail from '../clients/Newtail'
+import Newtail from '../../clients/Newtail'
 import type {
   NewtailResponse,
   NewtailPlacement,
   PlacementResponse,
   NewtailRequest,
-} from '../typings/Newtail'
-import { shouldFetchSponsoredProducts } from '../utils/shouldFetchSponsoredProducts'
+} from '../../typings/Newtail'
+import {getNewtailPublisherId} from '../../utils/getNewtailPublisherID'
+import { shouldFetchSponsoredProducts } from '../../utils/shouldFetchSponsoredProducts'
 
 const RULE_ID = 'sponsoredProduct'
 const PRODUCT_SKU_IDENTIFIER_FIELD = 'skuId'
@@ -111,7 +112,8 @@ export async function newtailSponsoredProducts(
       session_id: args.macId,
     }
 
-    const newtailResponse = await ctx.clients.newtail.getSponsoredProducts(body)
+    const publisherId = await getNewtailPublisherId(ctx)
+    const newtailResponse = await ctx.clients.newtail.getSponsoredProducts(body, publisherId)
 
     return mapSponsoredProduct(newtailResponse, args.placement)
   } catch (error) {

--- a/node/resolvers/sponsoredProducts/vtex.ts
+++ b/node/resolvers/sponsoredProducts/vtex.ts
@@ -1,11 +1,11 @@
-import AdServer from '../clients/AdServer'
+import AdServer from '../../clients/AdServer'
 import type {
   AdServerResponse,
   AdServerSearchParams,
-} from '../typings/AdServer'
-import compact from '../utils/compact'
-import region from '../utils/region'
-import { shouldFetchSponsoredProducts } from '../utils/shouldFetchSponsoredProducts'
+} from '../../typings/AdServer'
+import compact from '../../utils/compact'
+import region from '../../utils/region'
+import { shouldFetchSponsoredProducts } from '../../utils/shouldFetchSponsoredProducts'
 
 const RULE_ID = 'sponsoredProduct'
 const PRODUCT_UNIQUE_IDENTIFIER_FIELD = 'product'
@@ -53,7 +53,7 @@ const mapSponsoredProduct = (
   )
 }
 
-export async function sponsoredProducts(
+export async function vtexSponsoredProducts(
   _: unknown,
   args: SponsoredProductsParams,
   ctx: Context

--- a/node/typings/Newtail.ts
+++ b/node/typings/Newtail.ts
@@ -1,0 +1,44 @@
+export type NewtailRequest = {
+  term?: string
+  context?: 'search' | 'home' | 'category',
+  category_name?: string,
+  placements?: { [key: string]: NewtailPlacement }
+  user_id?: string
+  session_id?: string
+}
+
+export type NewtailPlacement = {
+  quantity: number
+  types: string[]
+}
+
+export interface NewtailResponse {
+  query_at: string
+  query_id: string
+  request_id: string
+  validations: any[] | undefined
+  [key: string]: PlacementResponse[] | string | undefined
+}
+
+export type NewtailSearchParams = Pick<SearchParams, NewtailSearchParamsKeys>
+
+type NewtailSearchParamsKeys = 'query' | 'selectedFacets'
+
+export type PlacementResponse = {
+  ad_id: string
+
+  click_url: string
+  impression_url: string
+  view_url: string
+  position: number
+
+  product_sku: string
+  seller_id?: string
+  type: string
+
+  product_metadata: ProductMetadata
+}
+
+export type ProductMetadata = {
+  productId: string
+}

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -68,12 +68,12 @@ declare global {
     identifier: ProductUniqueIdentifier
     rule: Rule
     advertisement?: Advertisement
-    sellerId?: string
   }
 
   type ProductUniqueIdentifier = {
     field: ProductUniqueIdentifierField
     value: string
+    sellerId?: string
   }
 
   type ProductUniqueIdentifierField = 'anuId' | 'skuId' | 'product'

--- a/node/utils/getNewtailPublisherID.ts
+++ b/node/utils/getNewtailPublisherID.ts
@@ -1,0 +1,13 @@
+export const getNewtailPublisherId = async (ctx: Context) => {
+  const settings = await ctx.clients.apps.getAppSettings(
+    'vtex.adserver-resolver'
+  )
+
+  const publisherId = settings?.newtailPublisherId
+
+  if (!publisherId) {
+    throw new Error('Newtail publisher ID not found')
+  }
+
+  return publisherId
+}

--- a/node/utils/shouldUseNewtail.ts
+++ b/node/utils/shouldUseNewtail.ts
@@ -1,0 +1,7 @@
+export const shouldUseNewtail = async (ctx: Context) => {
+  const settings = await ctx.clients.apps.getAppSettings(
+    'vtex.adserver-resolver'
+  )
+
+  return settings?.enableNewtail ?? false
+}


### PR DESCRIPTION
## Purpose

Provide a more seamless switch from VTEX to Newtail Ad Server.

### Description

Previously, to change between VTEX and Newtail Ad Server resolvers, we had to uninstall one app and install another (the other being [vtex/newtail-resolver](https://github.com/vtex-apps/newtail-resolver)).

This change incorporates the source code from the other app. It allows a more seamless switch (without having to use the terminal, for example) and will allow us to use both at the same time in the future, if needed.

Review tip: since this PR copies source from the other app, you may find easier to look the [diff without the first commit](https://github.com/vtex-apps/adserver-resolver/pull/22/files/23dde9bed3494de4519d5249425a643dd16f2446..94424644135da33fc11529288b3138e1deaafbdc).

### Configuration page

It's possible to setup Newtail ads serving in the following settings page (replace `PUBLISHER_ACCOUNT` with the account name):

`https://PUBLISHER_ACCOUNT.myvtex.com/admin/apps/vtex.adserver-resolver@2.4.0/setup`

The configuration page looks like this:

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/c2fb610c-4c55-420b-82dd-2d1b5419ef2c" />

#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
