### PR TITLE
feat(newtail): add tags built from productClusterIds

### DIFF
--- a/node/resolvers/sponsoredProducts/newtail.ts
+++ b/node/resolvers/sponsoredProducts/newtail.ts
@@ -103,6 +103,12 @@ export async function newtailSponsoredProducts(
 
     const context = args?.query?.length ? 'search' : (categoryName ? 'category' : 'home')
 
+    const tags = args?.selectedFacets?.length && args.selectedFacets.some((facet) => facet.key.startsWith("productClusterIds"))
+      ? args.selectedFacets
+          .filter((facet) => facet.key.startsWith("productClusterIds"))
+          .map((facet) => `product_cluster/${facet.value}`)
+      : undefined;
+
     const body: NewtailRequest = {
       term: args.query,
       context,
@@ -110,6 +116,7 @@ export async function newtailSponsoredProducts(
       placements: definePlacements(adsAmount, args.placement),
       user_id: args.userId,
       session_id: args.macId,
+      tags,
     }
 
     const publisherId = await getNewtailPublisherId(ctx)

--- a/node/resolvers/sponsoredProducts/newtail.ts
+++ b/node/resolvers/sponsoredProducts/newtail.ts
@@ -103,9 +103,9 @@ export async function newtailSponsoredProducts(
 
     const context = args?.query?.length ? 'search' : (categoryName ? 'category' : 'home')
 
-    const tags = args?.selectedFacets?.length && args.selectedFacets.some((facet) => facet.key.startsWith("productClusterIds"))
+    const tags = args?.selectedFacets?.length && args.selectedFacets.some((facet) => facet.key === "productClusterIds")
       ? args.selectedFacets
-          .filter((facet) => facet.key.startsWith("productClusterIds"))
+          .filter((facet) => facet.key === "productClusterIds")
           .map((facet) => `product_cluster/${facet.value}`)
       : undefined;
 

--- a/node/typings/Newtail.ts
+++ b/node/typings/Newtail.ts
@@ -5,6 +5,7 @@ export type NewtailRequest = {
   placements?: { [key: string]: NewtailPlacement }
   user_id?: string
   session_id?: string
+  tags?: string[]
 }
 
 export type NewtailPlacement = {


### PR DESCRIPTION
## What is the purpose of this pull request?

To pass productClusterIds as tags into newtail ad request ([see official doc of their API here](https://newtail-media.readme.io/reference/product-ads)).
- `tags` will be sent if there is a `selectedFacet` with `key` starting by `productClusterIds`
  - The value will be part of an array of strings representing the `tags`
  - The `product_cluster/` prefix was determined by newtail tech team

OBS.: This implementation will only work if the `productClusterIds` comes as part of the path of the IS API request, example below. [I found this doc where the ID is defined in the URL previously to the productClusterIds label](https://developers.vtex.com/docs/guides/how-search-parameters-work) (Default 2 section), so no tags would be found. 

```
curl --location 'https://adstags--americanas.myvtex.com/_v/api/intelligent-search/product_search/productClusterIds/241?salesChannel=2&query=&count=5&page=1&simulationBehavior=default&showSponsored=true&macId=d418fd90-3a13-499d-bfb0-d2503c02ebf6' 
```

## Example

The request above returns an advertisement in `americanas` account at `adstags` workspace:
![image](https://github.com/user-attachments/assets/569f0ece-cd73-4412-8c25-a179023afd12)

Via [graphql](https://adstags--americanas.myvtex.com/admin/graphql-ide) we can also check we have ads returning based on the productClusterIds (tags):
![image](https://github.com/user-attachments/assets/4fcbe8ff-ba2b-4c12-a2e8-5b4fe773f1a6)


#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
