### PR TITLE
feat: SKU segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Allow ads segmentation by SKU ID.
+
 ## [2.6.0] - 2025-03-25
 
 ## [2.5.0] - 2025-03-19

--- a/node/resolvers/sponsoredProducts/newtail.ts
+++ b/node/resolvers/sponsoredProducts/newtail.ts
@@ -117,6 +117,7 @@ export async function newtailSponsoredProducts(
       user_id: args.userId,
       session_id: args.macId,
       tags,
+      product_sku: args.skuId,
     }
 
     const publisherId = await getNewtailPublisherId(ctx)

--- a/node/typings/Newtail.ts
+++ b/node/typings/Newtail.ts
@@ -6,6 +6,7 @@ export type NewtailRequest = {
   user_id?: string
   session_id?: string
   tags?: string[]
+  product_sku?: string
 }
 
 export type NewtailPlacement = {

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -40,6 +40,7 @@ declare global {
     sponsoredCount?: number
     macId?: string
     userId?: string
+    skuId?: string
   }
 
   type SearchParams = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR allows ads segmentation by SKU by passing the SKU ID argument in the query.

Check https://github.com/vtex/intelligent-search-api/pull/153.

#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
