### PR TITLE
fix: Pass empty query instead of not passing

### DIFF
--- a/node/clients/AdServer.ts
+++ b/node/clients/AdServer.ts
@@ -31,6 +31,8 @@ class AdServer extends ExternalClient {
       )
     }
 
+    body.searchParams.query = body.searchParams.query ?? ''
+
     return this.http.post('/api/v1/sponsored-products', {
       accountName: this.context.account,
       ...body,


### PR DESCRIPTION
#### What is the purpose of this pull request?

There's an ongoing incident that started this morning because some app was querying for sponsored shelves without setting the `query` parameter.

#### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
