### PR TITLE
fix: consider c as a possible category facet

### DIFF
--- a/node/resolvers/sponsoredProducts/newtail.ts
+++ b/node/resolvers/sponsoredProducts/newtail.ts
@@ -114,9 +114,9 @@ export async function newtailSponsoredProducts(
     const adsAmount = args.sponsoredCount ?? DEFAULT_SPONSORED_COUNT
 
     const categoryName =
-      args?.selectedFacets?.length && args.selectedFacets.some((facet) => facet.key.startsWith("category"))
+      args?.selectedFacets?.length && args.selectedFacets.some((facet) => (facet.key.startsWith("category") || facet.key === "c"))
         ? args.selectedFacets
-            .filter((facet) => facet.key.startsWith("category"))
+            .filter((facet) => (facet.key.startsWith("category") || facet.key === "c"))
             .map((facet) => facet.value)
             .join(" > ")
         : undefined;


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

To consider `c` as a possible category facet (is the default for CMS and store framework). Without this change, we were using the more generic newtail `context` (`home`) even when the `c` facet was defined, resulting in random ads for category pages.

Example of query in `newads` workspace at `drogal`:
```
query {
  sponsoredProducts(
    query: "", 
    selectedFacets: [
    	{key: "c", value: "farmacia-em-casa"}
    ],
    sponsoredCount: 3,
  ) 
  {
    advertisement {
      adId
    }
  }
}
```
![image](https://github.com/user-attachments/assets/1fd5f3bd-037e-4c0c-80ff-c695b5534d5d)


#### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
