### PR TITLE
feat: consider b facet to send newtail request with brand context

### DIFF
--- a/node/resolvers/sponsoredProducts/newtail.ts
+++ b/node/resolvers/sponsoredProducts/newtail.ts
@@ -121,7 +121,14 @@ export async function newtailSponsoredProducts(
             .join(" > ")
         : undefined;
 
-    const context = args?.query?.length ? 'search' : (categoryName ? 'category' : 'home')
+    const brandName = 
+      args?.selectedFacets?.length && args.selectedFacets.some((facet) => facet.key === "b")
+        ? args.selectedFacets
+            .filter((facet) => facet.key === "b")
+            .map((facet) => facet.value)[0]
+        : undefined;
+
+    const context = args?.query?.length ? 'search' : (categoryName ? 'category' : (brandName ? 'brand_page' : 'home'))
 
     const tags = args?.selectedFacets?.length && args.selectedFacets.some((facet) => facet.key === "productClusterIds")
       ? args.selectedFacets
@@ -138,6 +145,7 @@ export async function newtailSponsoredProducts(
       session_id: hasMacId ? args.macId : DEFAULT_SESSION_ID,
       tags,
       product_sku: args.skuId,
+      brand_name: brandName,
     }
 
     const publisherId = await getNewtailPublisherId(ctx)

--- a/node/typings/Newtail.ts
+++ b/node/typings/Newtail.ts
@@ -1,12 +1,13 @@
 export type NewtailRequest = {
   term?: string
-  context?: 'search' | 'home' | 'category',
+  context?: 'search' | 'home' | 'category' | 'brand_page',
   category_name?: string,
   placements?: { [key: string]: NewtailPlacement }
   user_id?: string
   session_id?: string
   tags?: string[]
   product_sku?: string
+  brand_name?: string
 }
 
 export type NewtailPlacement = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

To also consider `b` facet (representing a brand) for sending an ad request for brands instead of generic (with `context` `home`).

#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
