### PR TITLE
Add  as a new type of facet

### DIFF
--- a/node/resolvers/sponsoredProducts/newtail.ts
+++ b/node/resolvers/sponsoredProducts/newtail.ts
@@ -115,9 +115,9 @@ export async function newtailSponsoredProducts(
     const adsAmount = args.sponsoredCount ?? DEFAULT_SPONSORED_COUNT
 
     const categoryName =
-      args?.selectedFacets?.length && args.selectedFacets.some((facet) => (facet.key.startsWith("category") || facet.key === "c"))
+      args?.selectedFacets?.length && args.selectedFacets.some((facet) => (facet.key.startsWith("category") || facet.key === "c" || facet.key === "categoria"))
         ? args.selectedFacets
-            .filter((facet) => (facet.key.startsWith("category") || facet.key === "c"))
+            .filter((facet) => (facet.key.startsWith("category") || facet.key === "c" || facet.key === "categoria"))
             .map((facet) => facet.value)
             .join(" > ")
         : undefined;


### PR DESCRIPTION
#### What is the purpose of this pull request?

At Drogaria Venancio, they use a specific keyword (categoria) to define category specifications, as shown in this URL: https://adstest--drogariavenancio.myvtex.com/cuidados-com-o-rosto/especial-dia-das-maes?map=categoria,productclusternames. This means that in our current mapping, this particular keyword is not being recognized or mapped correctly.

<!--- Describe your changes in detail. -->

#### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
