### PR TITLE
fix: don't return ads after the first page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "adserver-resolver",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "title": "Ad Server Resolver",
   "description": "Configurations for sponsored products on your store",
   "builders": {

--- a/node/utils/shouldFetchSponsoredProducts.ts
+++ b/node/utils/shouldFetchSponsoredProducts.ts
@@ -21,6 +21,10 @@ const shouldFetchOnProductClusers = async (ctx: Context) => {
   return settings?.enableAdsOnCollections ?? true
 }
 
+const isFirstPage = (args: SearchParams) => {
+  return args.page === undefined || args.page.toString() === '1'
+}
+
 /**
  * Determine whether or not to fetch sponsored products based on a few parameters:
  * 1. If the search is not sorted by relevance, don't fetch.
@@ -32,7 +36,11 @@ export const shouldFetchSponsoredProducts = async (
   ctx: Context
 ) => {
   if (!isSortedByRelevance(args)) return false
-  if (!queryHasProductClusters(args)) return true
+  if (!isFirstPage(args)) return false
+
+  if (!queryHasProductClusters(args)) {
+    return true
+  }
 
   return shouldFetchOnProductClusers(ctx)
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Don't return sponsored products after the first search page.

#### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
