### PR TITLE
Fix/ads placement default

### DIFF
--- a/node/__tests__/resolvers/newtailSponsoredProducts.test.ts
+++ b/node/__tests__/resolvers/newtailSponsoredProducts.test.ts
@@ -1,12 +1,23 @@
-import { newtailSponsoredProducts } from '../../resolvers/sponsoredProducts/newtail'
+import { resolvers } from '../../resolvers'
 import type { NewtailResponse } from '../../typings/Newtail'
-
-// Mock OpenTelemetry dependencies
-jest.mock('@vtex/diagnostics-nodejs', () => ({}))
 
 const getSponsoredProductsSpy = jest.fn()
 const getNewtailPublisherIdSpy = jest.fn()
 const getAppSettingsSpy = jest.fn()
+const shouldUseNewtailSpy = jest.fn()
+
+// Mock utility functions
+jest.mock('../../utils/shouldUseNewtail', () => ({
+  shouldUseNewtail: () => shouldUseNewtailSpy(),
+}))
+
+jest.mock('../../utils/getNewtailPublisherID', () => ({
+  getNewtailPublisherId: () => getNewtailPublisherIdSpy(),
+}))
+
+jest.mock('../../utils/shouldFetchSponsoredProducts', () => ({
+  shouldFetchSponsoredProducts: jest.fn().mockResolvedValue(true),
+}))
 
 const mockNewtailResponse: NewtailResponse = {
   query_at: '2026-02-23T12:00:00Z',
@@ -47,20 +58,15 @@ const defaultContext = {
   },
 }
 
-jest.mock('../../utils/getNewtailPublisherID', () => ({
-  getNewtailPublisherId: () => getNewtailPublisherIdSpy(),
-}))
-
-jest.mock('../../utils/shouldFetchSponsoredProducts', () => ({
-  shouldFetchSponsoredProducts: jest.fn().mockResolvedValue(true),
-}))
-
 describe('newtailSponsoredProducts - placement definition', () => {
+  const query = resolvers.Query.sponsoredProducts
+
   beforeEach(() => {
     jest.clearAllMocks()
     getSponsoredProductsSpy.mockResolvedValue(mockNewtailResponse)
     getNewtailPublisherIdSpy.mockResolvedValue('publisher-123')
     getAppSettingsSpy.mockResolvedValue({ enableAdsOnCollections: true })
+    shouldUseNewtailSpy.mockResolvedValue(true)
   })
 
   describe('when placement is null', () => {
@@ -76,7 +82,7 @@ describe('newtailSponsoredProducts - placement definition', () => {
 
     it('should use "ads_newtail" as placement key instead of "null"', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await newtailSponsoredProducts({}, args, defaultContext as any)
+      await query({}, args, defaultContext as any)
 
       const callArgs = getSponsoredProductsSpy.mock.calls[0][0]
       
@@ -104,7 +110,7 @@ describe('newtailSponsoredProducts - placement definition', () => {
 
     it('should use "ads_newtail" as placement key', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await newtailSponsoredProducts({}, args, defaultContext as any)
+      await query({}, args, defaultContext as any)
 
       const callArgs = getSponsoredProductsSpy.mock.calls[0][0]
       
@@ -129,7 +135,7 @@ describe('newtailSponsoredProducts - placement definition', () => {
 
     it('should use the provided placement name', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await newtailSponsoredProducts({}, args, defaultContext as any)
+      await query({}, args, defaultContext as any)
 
       const callArgs = getSponsoredProductsSpy.mock.calls[0][0]
       

--- a/node/__tests__/resolvers/newtailSponsoredProducts.test.ts
+++ b/node/__tests__/resolvers/newtailSponsoredProducts.test.ts
@@ -1,0 +1,143 @@
+import { newtailSponsoredProducts } from '../../resolvers/sponsoredProducts/newtail'
+import type { NewtailResponse } from '../../typings/Newtail'
+
+// Mock OpenTelemetry dependencies
+jest.mock('@vtex/diagnostics-nodejs', () => ({}))
+
+const getSponsoredProductsSpy = jest.fn()
+const getNewtailPublisherIdSpy = jest.fn()
+const getAppSettingsSpy = jest.fn()
+
+const mockNewtailResponse: NewtailResponse = {
+  query_at: '2026-02-23T12:00:00Z',
+  query_id: 'query-123',
+  request_id: 'request-456',
+  validations: undefined,
+  ads_newtail: [
+    {
+      ad_id: 'ad-1',
+      click_url: 'https://example.com/click',
+      impression_url: 'https://example.com/impression',
+      view_url: 'https://example.com/view',
+      position: 1,
+      product_sku: 'sku-123',
+      seller_id: 'seller-1',
+      type: 'product',
+      product_metadata: {
+        productId: 'product-123',
+      },
+    },
+  ],
+}
+
+const defaultContext = {
+  vtex: {
+    logger: {
+      error: jest.fn(),
+      warn: jest.fn(),
+    },
+  },
+  clients: {
+    newtail: {
+      getSponsoredProducts: getSponsoredProductsSpy,
+    },
+    apps: {
+      getAppSettings: getAppSettingsSpy,
+    },
+  },
+}
+
+jest.mock('../../utils/getNewtailPublisherID', () => ({
+  getNewtailPublisherId: () => getNewtailPublisherIdSpy(),
+}))
+
+jest.mock('../../utils/shouldFetchSponsoredProducts', () => ({
+  shouldFetchSponsoredProducts: jest.fn().mockResolvedValue(true),
+}))
+
+describe('newtailSponsoredProducts - placement definition', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getSponsoredProductsSpy.mockResolvedValue(mockNewtailResponse)
+    getNewtailPublisherIdSpy.mockResolvedValue('publisher-123')
+    getAppSettingsSpy.mockResolvedValue({ enableAdsOnCollections: true })
+  })
+
+  describe('when placement is null', () => {
+    const args = {
+      query: '',
+      sponsoredCount: 6,
+      placement: null,
+      userId: 'user-123',
+      macId: 'f6b0c284-bd5c-4ba2-b474-606722f2a15f',
+      selectedFacets: [{ key: 'productClusterIds', value: '1011' }],
+      skuId: undefined,
+    }
+
+    it('should use "ads_newtail" as placement key instead of "null"', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await newtailSponsoredProducts({}, args, defaultContext as any)
+
+      const callArgs = getSponsoredProductsSpy.mock.calls[0][0]
+      
+      // Should have "ads_newtail" key, not "null"
+      expect(callArgs.placements).toHaveProperty('ads_newtail')
+      expect(callArgs.placements).not.toHaveProperty('null')
+      
+      expect(callArgs.placements.ads_newtail).toEqual({
+        quantity: 6,
+        types: ['product'],
+      })
+    })
+  })
+
+  describe('when placement is undefined', () => {
+    const args = {
+      query: '',
+      sponsoredCount: 3,
+      placement: undefined,
+      userId: 'user-123',
+      macId: 'session-id',
+      selectedFacets: [],
+      skuId: undefined,
+    }
+
+    it('should use "ads_newtail" as placement key', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await newtailSponsoredProducts({}, args, defaultContext as any)
+
+      const callArgs = getSponsoredProductsSpy.mock.calls[0][0]
+      
+      expect(callArgs.placements).toHaveProperty('ads_newtail')
+      expect(callArgs.placements.ads_newtail).toEqual({
+        quantity: 3,
+        types: ['product'],
+      })
+    })
+  })
+
+  describe('when custom placement is provided', () => {
+    const args = {
+      query: '',
+      sponsoredCount: 5,
+      placement: 'custom_placement',
+      userId: 'user-123',
+      macId: 'session-id',
+      selectedFacets: [],
+      skuId: undefined,
+    }
+
+    it('should use the provided placement name', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await newtailSponsoredProducts({}, args, defaultContext as any)
+
+      const callArgs = getSponsoredProductsSpy.mock.calls[0][0]
+      
+      expect(callArgs.placements).toHaveProperty('custom_placement')
+      expect(callArgs.placements.custom_placement).toEqual({
+        quantity: 5,
+        types: ['product'],
+      })
+    })
+  })
+})

--- a/node/resolvers/sponsoredProducts/newtail.ts
+++ b/node/resolvers/sponsoredProducts/newtail.ts
@@ -143,11 +143,13 @@ export async function newtailSponsoredProducts(
       .map((facet) => `product_cluster/${facet.value}`)
     ;
 
+    const placementName = args.placement ?? DEFAULT_PLACEMENT_NAME
+
     const body: NewtailRequest = {
       term: args.query,
       context,
       category_name: categoryName,
-      placements: definePlacements(adsAmount, args.placement),
+      placements: definePlacements(adsAmount, placementName),
       user_id: args.userId,
       session_id: hasMacId ? args.macId : DEFAULT_SESSION_ID,
       tags: (tags && tags?.length > 0) ? tags : undefined,
@@ -158,7 +160,7 @@ export async function newtailSponsoredProducts(
     const publisherId = await getNewtailPublisherId(ctx)
     const newtailResponse = await ctx.clients.newtail.getSponsoredProducts(body, publisherId)
 
-    return mapSponsoredProduct(newtailResponse, hasMacId, args.placement)
+    return mapSponsoredProduct(newtailResponse, hasMacId, placementName)
   } catch (error) {
     if (error.response?.data === Newtail.ERROR_MESSAGES.AD_NOT_FOUND) return []
 

--- a/node/typings/AdServer.ts
+++ b/node/typings/AdServer.ts
@@ -3,7 +3,7 @@ export type AdServerRequest = {
   count: number
   searchParams: AdServerSearchParams
   userId?: string
-  placement?: string
+  placement?: string | null
 }
 
 export type AdServerResponse = {

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -36,7 +36,7 @@ declare global {
   }
 
   type SponsoredProductsParams = SearchParams & {
-    placement?: string
+    placement?: string | null
     sponsoredCount?: number
     macId?: string
     userId?: string


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

Consider a possible `null` value for the sponsoredProducts query parameter `placement` and apply the default value `ads_newtail` before making the proper ad request (previous implementation only covered potential `undefined` `placement`, which led to `"null"` string accepted as a defined value).

#### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (changes configuration files, GitHub workflows, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
